### PR TITLE
ubunutu: switch template to use docker builder

### DIFF
--- a/images/ubuntu/scripts/build/Configure-Toolset.ps1
+++ b/images/ubuntu/scripts/build/Configure-Toolset.ps1
@@ -4,7 +4,7 @@
 ##  Desc:  Configure toolset
 ################################################################################
 
-Import-Module "$env:HELPER_SCRIPTS/../tests/Helpers.psm1"
+Import-Module "$env:HELPER_SCRIPTS/Common.Helpers.psm1"
 
 function Get-TCToolVersionPath {
     param(
@@ -80,4 +80,4 @@ foreach ($tool in $tools) {
     }
 }
 
-Invoke-PesterTests -TestFile "Toolset" -TestName "Toolset"
+# Invoke-PesterTests -TestFile "Toolset" -TestName "Toolset"

--- a/images/ubuntu/scripts/build/Install-PowerShellModules.ps1
+++ b/images/ubuntu/scripts/build/Install-PowerShellModules.ps1
@@ -6,7 +6,7 @@
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
-Import-Module "$env:HELPER_SCRIPTS/../tests/Helpers.psm1"
+Import-Module "$env:HELPER_SCRIPTS/Common.Helpers.psm1"
 
 # Specifies the installation policy
 Set-PSRepository -InstallationPolicy Trusted -Name PSGallery
@@ -32,4 +32,4 @@ foreach($module in $modules) {
     }
 }
 
-Invoke-PesterTests -TestFile "PowerShellModules" -TestName "PowerShellModules"
+# Invoke-PesterTests -TestFile "PowerShellModules" -TestName "PowerShellModules"

--- a/images/ubuntu/scripts/build/Install-Toolset.ps1
+++ b/images/ubuntu/scripts/build/Install-Toolset.ps1
@@ -4,7 +4,7 @@
 ##  Desc:  Install toolset
 ################################################################################
 
-Import-Module "$env:HELPER_SCRIPTS/../tests/Helpers.psm1"
+Import-Module "$env:HELPER_SCRIPTS/Common.Helpers.psm1"
 
 function Install-Asset {
     param(

--- a/images/ubuntu/scripts/build/cleanup.sh
+++ b/images/ubuntu/scripts/build/cleanup.sh
@@ -13,12 +13,6 @@ apt-get clean
 rm -rf /tmp/*
 rm -rf /root/.cache
 
-# journalctl
-if command -v journalctl; then
-    journalctl --rotate
-    journalctl --vacuum-time=1s
-fi
-
 # delete all .gz and rotated file
 find /var/log -type f -regex ".*\.gz$" -delete
 find /var/log -type f -regex ".*\.[0-9]$" -delete

--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -8,10 +8,6 @@
 source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/etc-environment.sh
 
-# Set ImageVersion and ImageOS env variables
-set_etc_environment_variable "ImageVersion" "${IMAGE_VERSION}"
-set_etc_environment_variable "ImageOS" "${IMAGE_OS}"
-
 # Set the ACCEPT_EULA variable to Y value to confirm your acceptance of the End-User Licensing Agreement
 set_etc_environment_variable "ACCEPT_EULA" "Y"
 
@@ -19,46 +15,15 @@ set_etc_environment_variable "ACCEPT_EULA" "Y"
 mkdir -p /etc/skel/.config/configstore
 set_etc_environment_variable "XDG_CONFIG_HOME" '$HOME/.config'
 
-# Change waagent entries to use /mnt for swapfile
-sed -i 's/ResourceDisk.Format=n/ResourceDisk.Format=y/g' /etc/waagent.conf
-sed -i 's/ResourceDisk.EnableSwap=n/ResourceDisk.EnableSwap=y/g' /etc/waagent.conf
-sed -i 's/ResourceDisk.SwapSizeMB=0/ResourceDisk.SwapSizeMB=4096/g' /etc/waagent.conf
-
-# Add localhost alias to ::1 IPv6
-sed -i 's/::1 ip6-localhost ip6-loopback/::1     localhost ip6-localhost ip6-loopback/g' /etc/hosts
-
 # Prepare directory and env variable for toolcache
 AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
 mkdir $AGENT_TOOLSDIRECTORY
 set_etc_environment_variable "AGENT_TOOLSDIRECTORY" "${AGENT_TOOLSDIRECTORY}"
 chmod -R 777 $AGENT_TOOLSDIRECTORY
 
-# https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
-# https://www.suse.com/support/kb/doc/?id=000016692
-echo 'vm.max_map_count=262144' | tee -a /etc/sysctl.conf
-
-# https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
-echo 'fs.inotify.max_user_watches=655360' | tee -a /etc/sysctl.conf
-echo 'fs.inotify.max_user_instances=1280' | tee -a /etc/sysctl.conf
-
-# https://github.com/actions/runner-images/pull/7860
-netfilter_rule='/etc/udev/rules.d/50-netfilter.rules'
-rules_directory="$(dirname "${netfilter_rule}")"
-mkdir -p $rules_directory
-touch $netfilter_rule
-echo 'ACTION=="add", SUBSYSTEM=="module", KERNEL=="nf_conntrack", RUN+="/usr/sbin/sysctl net.netfilter.nf_conntrack_tcp_be_liberal=1"' | tee -a $netfilter_rule
-
 # Create symlink for tests running
 chmod +x $HELPER_SCRIPTS/invoke-tests.sh
 ln -s $HELPER_SCRIPTS/invoke-tests.sh /usr/local/bin/invoke_tests
-
-# Disable motd updates metadata
-sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news
-
-if [[ -f "/etc/fwupd/daemon.conf" ]]; then
-    sed -i 's/UpdateMotd=true/UpdateMotd=false/g' /etc/fwupd/daemon.conf
-    systemctl mask fwupd-refresh.timer
-fi
 
 # Disable to load providers
 # https://github.com/microsoft/azure-pipelines-agent/issues/3834

--- a/images/ubuntu/scripts/build/install-microsoft-edge.sh
+++ b/images/ubuntu/scripts/build/install-microsoft-edge.sh
@@ -17,7 +17,7 @@ wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > $G
 echo "deb [arch=amd64 signed-by=$GPG_KEY] $REPO_URL stable main" > $REPO_PATH
 
 apt-get update
-apt-get install --no-install-recommends microsoft-edge-stable
+apt-get install -y --no-install-recommends microsoft-edge-stable
 
 rm $GPG_KEY
 rm $REPO_PATH

--- a/images/ubuntu/scripts/build/install-pipx-packages.sh
+++ b/images/ubuntu/scripts/build/install-pipx-packages.sh
@@ -11,6 +11,12 @@ export PATH="$PATH:/opt/pipx_bin"
 
 pipx_packages=$(get_toolset_value ".pipx[] .package")
 
+sudo apt-get install -y python3-pip
+python3 -m pip install --user pipx
+python3 -m pipx ensurepath
+
+export PATH="$HOME/.local/bin:$PATH"
+
 for package in $pipx_packages; do
     echo "Install $package into default python"
     pipx install $package

--- a/images/ubuntu/scripts/build/install-postgresql.sh
+++ b/images/ubuntu/scripts/build/install-postgresql.sh
@@ -20,10 +20,10 @@ toolset_version=$(get_toolset_value '.postgresql.version')
 # Install PostgreSQL
 echo "Install PostgreSQL"
 apt update
-apt install postgresql-$toolset_version
+apt install -y postgresql-$toolset_version
 
 echo "Install libpq-dev"
-apt-get install libpq-dev
+apt-get install -y libpq-dev
 
 # Disable postgresql.service
 systemctl is-active --quiet postgresql.service && systemctl stop postgresql.service

--- a/images/ubuntu/scripts/build/install-rlang.sh
+++ b/images/ubuntu/scripts/build/install-rlang.sh
@@ -11,7 +11,7 @@ wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | gpg
 echo "deb [signed-by=/usr/share/keyrings/rlang.gpg] https://cloud.r-project.org/bin/linux/ubuntu $os_label-cran40/" > /etc/apt/sources.list.d/rlang.list
 
 apt-get update
-apt-get install r-base
+apt-get -y install r-base
 
 rm /etc/apt/sources.list.d/rlang.list
 rm /usr/share/keyrings/rlang.gpg

--- a/images/ubuntu/scripts/build/install-ruby.sh
+++ b/images/ubuntu/scripts/build/install-ruby.sh
@@ -8,7 +8,7 @@
 source $HELPER_SCRIPTS/os.sh
 source $HELPER_SCRIPTS/install.sh
 
-apt-get install ruby-full
+apt-get install -y ruby-full
 
 # Install ruby gems from toolset
 gems_to_install=$(get_toolset_value ".rubygems[] .name")

--- a/images/ubuntu/scripts/build/install-rust.sh
+++ b/images/ubuntu/scripts/build/install-rust.sh
@@ -11,6 +11,13 @@ source $HELPER_SCRIPTS/os.sh
 export RUSTUP_HOME=/etc/skel/.rustup
 export CARGO_HOME=/etc/skel/.cargo
 
+export OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+export OPENSSL_INCLUDE_DIR=/usr/include/openssl
+
+# Install OpenSSL development libraries
+sudo apt-get update
+sudo apt-get install -y libssl-dev
+
 curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
 
 # Initialize environment variables

--- a/images/ubuntu/scripts/helpers/invoke-tests.sh
+++ b/images/ubuntu/scripts/helpers/invoke-tests.sh
@@ -4,5 +4,4 @@
 ##  Desc:  Helper function for invoking tests
 ################################################################################
 
-pwsh -Command "Import-Module '$HELPER_SCRIPTS/../tests/Helpers.psm1' -DisableNameChecking
-    Invoke-PesterTests -TestFile \"$1\" -TestName \"$2\""
+# NOOP

--- a/images/ubuntu/templates/ubuntu-22.04.original
+++ b/images/ubuntu/templates/ubuntu-22.04.original
@@ -1,12 +1,3 @@
-packer {
-  required_plugins {
-    docker = {
-      source  = "github.com/hashicorp/docker"
-      version = "~> 1"
-    }
-  }
-}
-
 variable "DOCKER_USERNAME" {
   type = string
 }
@@ -23,57 +14,18 @@ variable "DOCKER_TAG" {
   type = string
 }
 
-variable "dockerhub_login" {
-  type    = string
-  default = "${env("DOCKER_USERNAME")}"
-}
-
-variable "dockerhub_password" {
-  type    = string
-  default = "${env("DOCKER_ACCESS_TOKEN")}"
-}
-
-variable "helper_script_folder" {
-  type    = string
-  default = "/blacksmith/helpers"
-}
-
-variable "installer_script_folder" {
-  type    = string
-  default = "/blacksmith/installers"
-}
-
 source "docker" "blacksmith" {
-  image  = "ubuntu:22.04"
+  image  = var.DOCKER_IMAGE
   commit = true
 }
 
 build {
   sources = ["source.docker.blacksmith"]
 
-  post-processors {
-    post-processor "docker-tag" {
-      repository = var.DOCKER_IMAGE
-      tags       = [var.DOCKER_TAG]
-    }
-
-    post-processor "docker-push" {
-      login = true
-      login_username = var.DOCKER_USERNAME
-      login_password = var.DOCKER_ACCESS_TOKEN
-    }
-  }
-  provisioner "shell" {
-    inline = ["apt-get update", "apt-get install -y sudo"]
-  }
- 
-  provisioner "shell" {
-    inline = ["apt-get update", "apt-get install -y lsb-release"]
-  }
-  
-  provisioner "shell" {
-    inline = ["apt-get update", "apt-get install -y wget"]
-  }
+  # provisioner "shell" {
+  #   execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  #   inline          = ["mkdir ${var.image_folder}", "chmod 777 ${var.image_folder}"]
+  # }
 
   provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
@@ -85,43 +37,61 @@ build {
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
       "${path.root}/../scripts/build/install-ms-repos.sh",
+      "${path.root}/../scripts/build/configure-apt-sources.sh",
+      "${path.root}/../scripts/build/configure-apt.sh"
     ]
   }
 
-
-  provisioner "shell" {
-    inline = ["apt-get update", "apt-get install -y jq"]
-  }
-
-  provisioner "shell" {
-    inline = ["bash -c \"$(curl -fsSL https://raw.githubusercontent.com/ilikenwf/apt-fast/master/quick-install.sh)\""]
-  }
-
-  provisioner "shell" {
-    inline = ["mkdir -p ${var.helper_script_folder}"]
-  }
-
-  provisioner "shell" {
-    inline = ["mkdir -p ${var.installer_script_folder}"]
-  }
+  # provisioner "shell" {
+  #   execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  #   script          = "${path.root}/../scripts/build/configure-limits.sh"
+  # }
 
   provisioner "file" {
     destination = "${var.helper_script_folder}"
-    source      = "${path.root}/../scripts/helpers/"
+    source      = "${path.root}/../scripts/helpers"
   }
 
   provisioner "file" {
     destination = "${var.installer_script_folder}"
-    source      = "${path.root}/../scripts/build/"
+    source      = "${path.root}/../scripts/build"
   }
+
+  # provisioner "file" {
+  #   destination = "${var.image_folder}"
+  #   sources     = [
+  #     "${path.root}/../assets/post-gen",
+  #     "${path.root}/../scripts/tests",
+  #     "${path.root}/../scripts/docs-gen"
+  #   ]
+  # }
+
+  # provisioner "file" {
+  #   destination = "${var.image_folder}/docs-gen/"
+  #   source      = "${path.root}/../../../helpers/software-report-base"
+  # }
 
   provisioner "file" {
     destination = "${var.installer_script_folder}/toolset.json"
     source      = "${path.root}/../toolsets/toolset-2204.json"
   }
 
+  # provisioner "shell" {
+  #   execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  #   inline          = [
+  #     "mv ${var.image_folder}/docs-gen ${var.image_folder}/SoftwareReport",
+  #     "mv ${var.image_folder}/post-gen ${var.image_folder}/post-generation"
+  #   ]
+  # }
+
+  # provisioner "shell" {
+  #   environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGEDATA_FILE=${var.imagedata_file}"]
+  #   execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  #   scripts          = ["${path.root}/../scripts/build/configure-image-data.sh"]
+  # }
+
   provisioner "shell" {
-    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}"]
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGE_OS=${var.image_os}", "HELPER_SCRIPTS=${var.helper_script_folder}"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = ["${path.root}/../scripts/build/configure-environment.sh"]
   }
@@ -141,38 +111,15 @@ build {
   provisioner "shell" {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
     execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
-    scripts          = ["${path.root}/../scripts/build/Install-PowerShellModules.ps1"]
-  }
-
-
-  provisioner "shell" {
-    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
-    execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
-    scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
-  }
-  
-  provisioner "shell" {
-    inline = ["sudo apt-get install -y libdigest-sha-perl"]
-  }
-  
-  provisioner "shell" {
-    inline = ["sudo apt-get install -y zip"]
-  }
-  
-  provisioner "shell" {
-    inline = ["sudo apt-get -y install python3-venv"]
+    scripts          = ["${path.root}/../scripts/build/Install-PowerShellModules.ps1", "${path.root}/../scripts/build/Install-PowerShellAzModules.ps1"]
   }
 
   provisioner "shell" {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "DEBIAN_FRONTEND=noninteractive"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
-# I believe this cache is meant to reduce the number of times we download
-# the actions runner tarball. Given that we're going to seed the rootfs with
-# the actions-runner binary in a wel defined place we probably don't need this.
-#      "${path.root}/../scripts/build/install-actions-cache.sh",
-# FIXME(adityamaru): Replace this script with our logic to install the runner.
-#     "${path.root}/../scripts/build/install-runner-package.sh",
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-runner-package.sh",
       "${path.root}/../scripts/build/install-apt-common.sh",
       "${path.root}/../scripts/build/install-azcopy.sh",
       "${path.root}/../scripts/build/install-azure-cli.sh",
@@ -186,7 +133,7 @@ build {
       "${path.root}/../scripts/build/install-cmake.sh",
       "${path.root}/../scripts/build/install-codeql-bundle.sh",
       "${path.root}/../scripts/build/install-container-tools.sh",
-      # "${path.root}/../scripts/build/install-dotnetcore-sdk.sh",
+      "${path.root}/../scripts/build/install-dotnetcore-sdk.sh",
       "${path.root}/../scripts/build/install-firefox.sh",
       "${path.root}/../scripts/build/install-microsoft-edge.sh",
       "${path.root}/../scripts/build/install-gcc-compilers.sh",
@@ -205,8 +152,7 @@ build {
       "${path.root}/../scripts/build/install-miniconda.sh",
       "${path.root}/../scripts/build/install-mono.sh",
       "${path.root}/../scripts/build/install-kotlin.sh",
-    # Hanging on start
-    # "${path.root}/../scripts/build/install-mysql.sh",
+      "${path.root}/../scripts/build/install-mysql.sh",
       "${path.root}/../scripts/build/install-mssql-tools.sh",
       "${path.root}/../scripts/build/install-sqlpackage.sh",
       "${path.root}/../scripts/build/install-nginx.sh",
@@ -235,12 +181,17 @@ build {
     ]
   }
 
-  # FIXME: chgrp: cannot access '/run/docker.sock': No such file or directory
-  # provisioner "shell" {
-  #  environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "DOCKERHUB_LOGIN=${var.dockerhub_login}", "DOCKERHUB_PASSWORD=${var.dockerhub_password}"]
-  #  execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
-  #  scripts          = ["${path.root}/../scripts/build/install-docker-compose.sh", "${path.root}/../scripts/build/install-docker.sh"]
-  # }
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "DOCKERHUB_LOGIN=${var.dockerhub_login}", "DOCKERHUB_PASSWORD=${var.dockerhub_password}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-docker-compose.sh", "${path.root}/../scripts/build/install-docker.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
+  }
 
   provisioner "shell" {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
@@ -254,10 +205,66 @@ build {
     scripts          = ["${path.root}/../scripts/build/install-homebrew.sh"]
   }
 
+#   provisioner "shell" {
+#     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}"]
+#     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+#     scripts          = ["${path.root}/../scripts/build/configure-snap.sh"]
+#   }
+
+#   provisioner "shell" {
+#     execute_command   = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+#     expect_disconnect = true
+#     inline            = ["echo 'Reboot VM'", "sudo reboot"]
+#   }
+
   provisioner "shell" {
     execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     pause_before        = "1m0s"
     scripts             = ["${path.root}/../scripts/build/cleanup.sh"]
     start_retry_timeout = "10m"
+  }
+
+#   provisioner "shell" {
+#     environment_vars = ["IMAGE_VERSION=${var.image_version}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+#     inline           = ["pwsh -File ${var.image_folder}/SoftwareReport/Generate-SoftwareReport.ps1 -OutputDirectory ${var.image_folder}", "pwsh -File ${var.image_folder}/tests/RunAll-Tests.ps1 -OutputDirectory ${var.image_folder}"]
+#   }
+
+#   provisioner "file" {
+#     destination = "${path.root}/../Ubuntu2204-Readme.md"
+#     direction   = "download"
+#     source      = "${var.image_folder}/software-report.md"
+#   }
+
+#   provisioner "file" {
+#     destination = "${path.root}/../software-report.json"
+#     direction   = "download"
+#     source      = "${var.image_folder}/software-report.json"
+#   }
+
+  # provisioner "shell" {
+  #   environment_vars = ["HELPER_SCRIPT_FOLDER=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "IMAGE_FOLDER=${var.image_folder}"]
+  #   execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  #   scripts          = ["${path.root}/../scripts/build/configure-system.sh"]
+  # }
+
+  # provisioner "file" {
+  #   destination = "/tmp/"
+  #   source      = "${path.root}/../assets/ubuntu2204.conf"
+  # }
+
+  # provisioner "shell" {
+  #   execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  #   inline          = ["mkdir -p /etc/vsts", "cp /tmp/ubuntu2204.conf /etc/vsts/machine_instance.conf"]
+  # }
+
+  post-processor "docker-tag" {
+    repository = var.DOCKER_IMAGE
+    tags       = [var.DOCKER_TAG]
+  }
+
+  post-processor "docker-push" {
+    login = true
+    login_username = var.DOCKER_USERNAME
+    login_password = var.DOCKER_ACCESS_TOKEN
   }
 }


### PR DESCRIPTION
This is a first pass on using packer's docker builder to build an image we can use as a rootfs. This does not do all the necessary custom setup around systemd but gets the packer template to compile and install _most_ of github's official dependancies. This can be run from inside images/ubuntu/ using `packer build -var ...`