### PR TITLE
Add RunAll-Tests.ps1 verification step to macOS-14 Packer templates

### DIFF
--- a/images/macos/templates/macOS-14.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.anka.pkr.hcl
@@ -237,7 +237,8 @@ build {
     environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     inline           = [
-      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}"
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
+      "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]
   }
 

--- a/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.anka.pkr.hcl
@@ -232,7 +232,8 @@ build {
     environment_vars = ["IMAGE_FOLDER=${local.image_folder}"]
     execute_command  = "source $HOME/.bash_profile; {{ .Vars }} {{ .Path }}"
     inline           = [
-      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}"
+      "pwsh -File \"${local.image_folder}/software-report/Generate-SoftwareReport.ps1\" -OutputDirectory \"${local.image_folder}/output/software-report\" -ImageName ${var.build_id}",
+      "pwsh -File \"${local.image_folder}/tests/RunAll-Tests.ps1\""
     ]
   }
 


### PR DESCRIPTION
The macOS-14 Packer templates (both arm64 and x64) were missing the `RunAll-Tests.ps1` verification step that all other macOS templates (11, 12, 13) already include. Without this step, the AWS CLI verification tests in `Common.Tests.ps1` — along with every other tool verification test — never ran during the final image validation phase of macOS-14 builds. The per-tool `invoke_tests` calls during installation still ran, but the comprehensive end-of-build verification was skipped.

This adds `pwsh -File "${local.image_folder}/tests/RunAll-Tests.ps1"` to the final provisioner's `inline` array in both `macOS-14.arm64.anka.pkr.hcl` and `macOS-14.anka.pkr.hcl`, matching the pattern already present in `macOS-13.arm64.anka.pkr.hcl`.

This is a verification-only change — it doesn't alter what gets installed or how tools are configured. It will add a few minutes to macOS-14 image builds as the full Pester test suite runs, which is the same behavior as all other macOS image builds.

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/FastActions/codesmith/runner-images/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews (Staging)
<!-- /codesmith:footer:staging -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/FastActions/codesmith/runner-images/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->