### PR TITLE
Add SHA256 manifests for build artifacts

### DIFF
--- a/images.CI/create-artifact-shasums.ps1
+++ b/images.CI/create-artifact-shasums.ps1
@@ -1,0 +1,40 @@
+Param
+(
+    [Parameter(Mandatory)]
+    [string] $ArtifactsDirectory,
+
+    [string] $ManifestName = "SHA256SUMS"
+)
+
+$ErrorActionPreference = "Stop"
+
+$pathTrimCharacters = [char[]] @(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar
+)
+
+$resolvedArtifactsDirectory = Resolve-Path -LiteralPath $ArtifactsDirectory
+$artifactsDirectoryPath = $resolvedArtifactsDirectory.ProviderPath.TrimEnd($pathTrimCharacters)
+$manifestPath = Join-Path $artifactsDirectoryPath $ManifestName
+
+if (Test-Path -LiteralPath $manifestPath) {
+    Remove-Item -LiteralPath $manifestPath -Force
+}
+
+$manifestLines = @(
+    Get-ChildItem -LiteralPath $artifactsDirectoryPath -File -Recurse |
+    Sort-Object -Property FullName |
+    ForEach-Object {
+        $relativePath = $_.FullName.Substring($artifactsDirectoryPath.Length)
+        $relativePath = $relativePath.TrimStart($pathTrimCharacters)
+        $relativePath = $relativePath.Replace([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+
+        $hash = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+        "$hash  $relativePath"
+    }
+)
+
+$utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllLines($manifestPath, [string[]] $manifestLines, $utf8NoBomEncoding)
+
+Write-Host "Created SHA256 manifest at $manifestPath"

--- a/images.CI/linux-and-win/azure-pipelines/image-generation.yml
+++ b/images.CI/linux-and-win/azure-pipelines/image-generation.yml
@@ -135,6 +135,13 @@ jobs:
             Get-Content -Path $softwareReportPath
         }
 
+  - task: PowerShell@2
+    displayName: 'Create artifact SHA256 manifest'
+    inputs:
+      targetType: 'filePath'
+      filePath: ./images.CI/create-artifact-shasums.ps1
+      arguments: -ArtifactsDirectory "$(Build.ArtifactStagingDirectory)"
+
   - task: PublishBuildArtifacts@1
     inputs:
       ArtifactName: 'Built_VM_Artifacts'

--- a/images.CI/macos/azure-pipelines/image-generation.yml
+++ b/images.CI/macos/azure-pipelines/image-generation.yml
@@ -111,6 +111,13 @@ jobs:
       cat "$(Build.ArtifactStagingDirectory)/systeminfo.json"
     displayName: Print json software report
 
+  - task: PowerShell@2
+    displayName: 'Create artifact SHA256 manifest'
+    inputs:
+      targetType: 'filePath'
+      filePath: ./images.CI/create-artifact-shasums.ps1
+      arguments: -ArtifactsDirectory "$(Build.ArtifactStagingDirectory)"
+
   - task: PublishBuildArtifacts@1
     inputs:
       ArtifactName: 'Built_VM_Artifacts'


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/FastActions/codesmith/runner-images/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783574748&installation_id=59837822&pr_number=33&repository=FastActions%2Frunner-images&return_to=https%3A%2F%2Fgithub.com%2FFastActions%2Frunner-images%2Fpull%2F33&signature=08b3b825a8541e32d77eb1f75d96e82acb9c107aca9763a4bbeb8a7b19f33e42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- codesmith:footer:staging -->
---
<a href="https://staging.blacksmith.sh/FastActions/codesmith/runner-images/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://stagingbackend.blacksmith.sh/track/enable-autofix?expires=1783574751&installation_id=57497211&pr_number=33&repository=FastActions%2Frunner-images&return_to=https%3A%2F%2Fgithub.com%2FFastActions%2Frunner-images%2Fpull%2F33&signature=355c41dc97250f0f70908378b65ebbf9f297256149a449f2ea096702b1af400d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled. (Staging)</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer:staging -->